### PR TITLE
Refactor and clean up codebase

### DIFF
--- a/planningpoker/settings.py
+++ b/planningpoker/settings.py
@@ -142,7 +142,10 @@ REST_FRAMEWORK = {
 SUID_ALPHABET = os.environ.get('PLANNING_POKER_SUID_ALPHABET')
 SUID_LENGTH = 10
 
-JWT_SECRET_KEY = os.environ.get('PLANNING_POKER_SUID_ALPHABET')
+JWT_SECRET_KEY = (
+    os.environ.get('PLANNING_POKER_JWT_SECRET_KEY')
+    or os.environ.get('PLANNING_POKER_SUID_ALPHABET')
+)
 
 # choices settings
 

--- a/room/admin.py
+++ b/room/admin.py
@@ -25,11 +25,9 @@ class IssueInlineAdmin(admin.TabularInline):
 
 class RoomAdmin(admin.ModelAdmin):
 
-    exclude = ()
     list_display = ('uid', 'title', 'description', 'issues_count',
                     'participants_count', 'updated', 'created',)
     readonly_fields = ('uid', 'updated', 'created',)
-
     inlines = [ParticipantInlineAdmin, IssueInlineAdmin]
 
     @staticmethod
@@ -45,7 +43,6 @@ class RoomAdmin(admin.ModelAdmin):
 
 class ParticipantAdmin(admin.ModelAdmin):
 
-    exclude = ()
     list_display = ('uid', 'room', 'name', 'votes_count', 'is_creator',
                     'updated', 'created',)
     readonly_fields = ('uid', 'updated', 'created',)
@@ -58,19 +55,25 @@ class ParticipantAdmin(admin.ModelAdmin):
 
 class IssueAdmin(admin.ModelAdmin):
 
-    exclude = ()
     list_display = ('uid', 'room', 'number', 'title', 'estimated_points',
                     'vote_cards_status', 'votes_count', 'updated', 'created',)
     readonly_fields = ('uid', 'updated', 'created',)
+    inlines = [VotesInlineAdmin]
 
     @staticmethod
     def votes_count(obj):
         """returns number of Votes for an Issue"""
         return obj.votes.count()
 
-    inlines = [VotesInlineAdmin]
+
+class VoteAdmin(admin.ModelAdmin):
+
+    list_display = ('uid', 'issue', 'participant', 'estimated_points',
+                    'updated', 'created',)
+    readonly_fields = ('uid', 'updated', 'created',)
 
 
 admin.site.register(Room, RoomAdmin)
 admin.site.register(Participant, ParticipantAdmin)
 admin.site.register(Issue, IssueAdmin)
+admin.site.register(Vote, VoteAdmin)

--- a/room/consumers.py
+++ b/room/consumers.py
@@ -6,59 +6,41 @@ class RoomConsumer(AsyncWebsocketConsumer):
 
     async def connect(self):
         self.room_uid = self.scope['url_route']['kwargs']['room_uid']
-        self.room_group_name = 'room_{room_uid}'.format(room_uid=self.room_uid)
+        self.room_group_name = 'room_{}'.format(self.room_uid)
 
-        # Join room group
         await self.channel_layer.group_add(
             self.room_group_name,
             self.channel_name
         )
-
         await self.accept()
 
     async def disconnect(self, close_code):
-        # Leave room group
         await self.channel_layer.group_discard(
             self.room_group_name,
             self.channel_name
         )
 
-    # Receive message from WebSocket
     async def receive(self, text_data):
-
-        text_data_json = json.loads(text_data)
-        message = text_data_json
-
-        # Send message to room group
+        message = json.loads(text_data)
         await self.channel_layer.group_send(
             self.room_group_name,
-            {
-                'type': 'current_issue',
-                'content': message['content']
-            }
+            {'type': 'current_issue', 'content': message['content']}
         )
 
-    async def current_issue(self, message):
-
-        # Send message to WebSocket
+    async def _forward_message(self, message):
         await self.send(text_data=json.dumps(message))
+
+    async def current_issue(self, message):
+        await self._forward_message(message)
 
     async def add_issue(self, message):
-
-        # Send message to WebSocket
-        await self.send(text_data=json.dumps(message))
+        await self._forward_message(message)
 
     async def add_participant(self, message):
-
-        # Send message to WebSocket
-        await self.send(text_data=json.dumps(message))
+        await self._forward_message(message)
 
     async def add_vote(self, message):
-
-        # Send message to WebSocket
-        await self.send(text_data=json.dumps(message))
+        await self._forward_message(message)
 
     async def update_issue(self, message):
-
-        # Send message to WebSocket
-        await self.send(text_data=json.dumps(message))
+        await self._forward_message(message)

--- a/room/models.py
+++ b/room/models.py
@@ -1,7 +1,7 @@
 import jwt
 from django.conf import settings
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from utils.base_model import BaseModel
 

--- a/room/permissions.py
+++ b/room/permissions.py
@@ -22,7 +22,8 @@ class IsRoomParticipantPermission(permissions.BasePermission):
             if request.participant.room.uid != view.kwargs.get('room_uid'):
                 return False
 
-        except (KeyError, InvalidSignatureError, DecodeError):
+        except (KeyError, InvalidSignatureError, DecodeError,
+                Participant.DoesNotExist):
             return False
 
         return True

--- a/room/serializers.py
+++ b/room/serializers.py
@@ -55,7 +55,7 @@ class JoinRoomInputSerializer(serializers.Serializer):
     name = serializers.CharField(required=True)
 
 
-class SubmitRoomCurrentIsseueInputSerializer(serializers.Serializer):
+class SubmitRoomCurrentIssueInputSerializer(serializers.Serializer):
     """Input serializer for set Room's current Issue."""
 
     issue_uid = serializers.CharField(required=True)

--- a/room/utils.py
+++ b/room/utils.py
@@ -1,0 +1,11 @@
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+
+
+def broadcast_room_event(room_uid, event_type, content):
+    """Send a group event to all WebSocket clients connected to a room."""
+    layer = get_channel_layer()
+    async_to_sync(layer.group_send)(
+        'room_{}'.format(room_uid),
+        {'type': event_type, 'content': content}
+    )

--- a/room/views.py
+++ b/room/views.py
@@ -1,5 +1,3 @@
-from asgiref.sync import async_to_sync
-from channels.layers import get_channel_layer
 from django.conf import settings
 from rest_framework import status
 from rest_framework.generics import (ListCreateAPIView, get_object_or_404,
@@ -15,7 +13,8 @@ from room.serializers import (RoomSerializer, JoinRoomInputSerializer,
                               ParticipantSerializer, IssueSerializer,
                               SubmitVoteInputSerializer, VoteSerializer,
                               RoomSerializerWithToken,
-                              SubmitRoomCurrentIsseueInputSerializer)
+                              SubmitRoomCurrentIssueInputSerializer)
+from room.utils import broadcast_room_event
 
 
 class RoomAPIView(ListCreateAPIView):
@@ -54,13 +53,9 @@ class JoinRoomAPIView(APIView):
         serializer = ParticipantSerializerWithToken(instance=participant)
 
         if created:
-            layer = get_channel_layer()
-            async_to_sync(layer.group_send)(
-                'room_{room_uid}'.format(room_uid=room.uid),
-                {
-                    'type': 'add_participant',
-                    'content': ParticipantSerializer(instance=participant).data
-                }
+            broadcast_room_event(
+                room.uid, 'add_participant',
+                ParticipantSerializer(instance=participant).data
             )
             return Response(data=serializer.data,
                             status=status.HTTP_201_CREATED)
@@ -87,20 +82,18 @@ class RoomIssueAPIView(ListCreateAPIView):
 
     def get_queryset(self):
         room = get_object_or_404(Room, uid=self.kwargs.get('room_uid'))
-        return Issue.objects.filter(room=room)
+        return Issue.objects.filter(room=room).prefetch_related(
+            'votes', 'votes__participant'
+        )
 
     def perform_create(self, serializer):
         room = get_object_or_404(Room, uid=self.kwargs.get('room_uid'))
         serializer.validated_data['room_id'] = room.id
         issue = serializer.save()
 
-        layer = get_channel_layer()
-        async_to_sync(layer.group_send)(
-            'room_{room_uid}'.format(room_uid=room.uid),
-            {
-                'type': 'add_issue',
-                'content': IssueSerializer(instance=issue).data
-            }
+        broadcast_room_event(
+            room.uid, 'add_issue',
+            IssueSerializer(instance=issue).data
         )
 
 
@@ -113,9 +106,7 @@ class RoomCurrentIssueAPIView(APIView):
 
         if not room.current_issue:
             return Response(
-                data={
-                    "details": "This room is don't have any current issue now"
-                },
+                data={"details": "This room doesn't have a current issue."},
                 status=status.HTTP_404_NOT_FOUND
             )
 
@@ -126,7 +117,7 @@ class RoomCurrentIssueAPIView(APIView):
         """Set Room's current Issue."""
 
         room = get_object_or_404(Room, uid=room_uid)
-        serializer = SubmitRoomCurrentIsseueInputSerializer(data=request.data)
+        serializer = SubmitRoomCurrentIssueInputSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         issue = get_object_or_404(Issue, uid=serializer.data.get('issue_uid'),
                                   room__uid=room.uid)
@@ -134,15 +125,7 @@ class RoomCurrentIssueAPIView(APIView):
         room.save()
 
         serializer = IssueSerializer(instance=issue)
-
-        layer = get_channel_layer()
-        async_to_sync(layer.group_send)(
-            'room_{room_uid}'.format(room_uid=room.uid),
-            {
-                'type': 'current_issue',
-                'content': serializer.data
-            }
-        )
+        broadcast_room_event(room.uid, 'current_issue', serializer.data)
 
         return Response(data=serializer.data, status=status.HTTP_200_OK)
 
@@ -155,19 +138,17 @@ class IssueAPIView(RetrieveUpdateDestroyAPIView):
 
     def get_queryset(self):
         room = get_object_or_404(Room, uid=self.kwargs.get('room_uid'))
-        return Issue.objects.filter(room=room)
+        return Issue.objects.filter(room=room).prefetch_related(
+            'votes', 'votes__participant'
+        )
 
     def perform_update(self, serializer):
         room = get_object_or_404(Room, uid=self.kwargs.get('room_uid'))
         issue = serializer.save()
 
-        layer = get_channel_layer()
-        async_to_sync(layer.group_send)(
-            'room_{room_uid}'.format(room_uid=room.uid),
-            {
-                'type': 'update_issue',
-                'content': IssueSerializer(instance=issue).data
-            }
+        broadcast_room_event(
+            room.uid, 'update_issue',
+            IssueSerializer(instance=issue).data
         )
 
 
@@ -192,15 +173,7 @@ class VoteAPIView(APIView):
         vote.save()
 
         serializer = VoteSerializer(instance=vote)
-
-        layer = get_channel_layer()
-        async_to_sync(layer.group_send)(
-            'room_{room_uid}'.format(room_uid=room_uid),
-            {
-                'type': 'add_vote',
-                'content': serializer.data
-            }
-        )
+        broadcast_room_event(room_uid, 'add_vote', serializer.data)
 
         if created:
             return Response(data=serializer.data, status=status.HTTP_201_CREATED)
@@ -211,7 +184,7 @@ class VoteAPIView(APIView):
         """Get votes of an Issue."""
 
         issue = get_object_or_404(Issue, uid=issue_uid, room__uid=room_uid)
-        votes = Vote.objects.filter(issue=issue)
+        votes = Vote.objects.filter(issue=issue).select_related('participant')
         serializer = VoteSerializer(instance=votes, many=True)
 
         return Response(data=serializer.data, status=status.HTTP_200_OK)
@@ -224,13 +197,9 @@ class VoteAPIView(APIView):
         issue.vote_cards_status = settings.HIDDEN
         issue.save()
 
-        layer = get_channel_layer()
-        async_to_sync(layer.group_send)(
-            'room_{room_uid}'.format(room_uid=room_uid),
-            {
-                'type': 'update_issue',
-                'content': IssueSerializer(instance=issue).data
-            }
+        broadcast_room_event(
+            room_uid, 'update_issue',
+            IssueSerializer(instance=issue).data
         )
 
         return Response(status=status.HTTP_204_NO_CONTENT)
@@ -252,14 +221,6 @@ class FlipIssueVoteCardsAPIView(APIView):
         issue.save()
 
         serializer = IssueSerializer(instance=issue)
-
-        layer = get_channel_layer()
-        async_to_sync(layer.group_send)(
-            'room_{room_uid}'.format(room_uid=room_uid),
-            {
-                'type': 'update_issue',
-                'content': serializer.data
-            }
-        )
+        broadcast_room_event(room_uid, 'update_issue', serializer.data)
 
         return Response(data=serializer.data, status=status.HTTP_200_OK)

--- a/utils/base_model.py
+++ b/utils/base_model.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from utils.helpers import generate_short_uuid
 


### PR DESCRIPTION
- Extract broadcast_room_event() helper in room/utils.py, eliminating 7
  duplicated async_to_sync channel layer calls across views.py
- Consolidate duplicate WebSocket consumer handlers into _forward_message()
- Fix SubmitRoomCurrentIsseueInputSerializer typo → SubmitRoomCurrentIssueInputSerializer
- Fix grammar error: "This room is don't have" → "This room doesn't have"
- Add prefetch_related('votes', 'votes__participant') to issue querysets
  and select_related('participant') to vote queries to avoid N+1 queries
- Add Participant.DoesNotExist to permissions exception handler to prevent 500s
- Replace deprecated ugettext_lazy with gettext_lazy in models.py and base_model.py
- Add VoteAdmin registration to admin.py; remove redundant exclude = () patterns
- Use a dedicated PLANNING_POKER_JWT_SECRET_KEY env var (falls back to
  PLANNING_POKER_SUID_ALPHABET for backward compatibility)

https://claude.ai/code/session_014qbZQtwZqpJHeLohsohpEE