### PR TITLE
Add real-time chat support and Docker containerisation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+venv/
+__pycache__/
+*.pyc
+*.pyo
+.env
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/planningpoker/settings.py
+++ b/planningpoker/settings.py
@@ -198,7 +198,7 @@ CHANNEL_LAYERS = {
     'default': {
         'BACKEND': 'channels_redis.core.RedisChannelLayer',
         'CONFIG': {
-            "hosts": [('127.0.0.1', 6379)],
+            "hosts": [(os.environ.get('REDIS_HOST', '127.0.0.1'), 6379)],
         },
     },
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ drf-yasg==1.21.15
 django-cors-headers==4.4.0
 channels==4.2.2
 channels-redis==4.2.1
+daphne==4.1.2

--- a/room/consumers.py
+++ b/room/consumers.py
@@ -1,4 +1,5 @@
 from channels.generic.websocket import AsyncWebsocketConsumer
+from datetime import datetime, timezone
 import json
 
 
@@ -22,10 +23,26 @@ class RoomConsumer(AsyncWebsocketConsumer):
 
     async def receive(self, text_data):
         message = json.loads(text_data)
-        await self.channel_layer.group_send(
-            self.room_group_name,
-            {'type': 'current_issue', 'content': message['content']}
-        )
+        msg_type = message.get('type')
+
+        if msg_type == 'chat_message':
+            await self.channel_layer.group_send(
+                self.room_group_name,
+                {
+                    'type': 'chat_message',
+                    'content': {
+                        'sender': message['content']['sender'],
+                        'senderUid': message['content'].get('senderUid'),
+                        'text': message['content']['text'],
+                        'timestamp': datetime.now(timezone.utc).isoformat(),
+                    },
+                }
+            )
+        else:
+            await self.channel_layer.group_send(
+                self.room_group_name,
+                {'type': 'current_issue', 'content': message['content']}
+            )
 
     async def _forward_message(self, message):
         await self.send(text_data=json.dumps(message))
@@ -43,4 +60,7 @@ class RoomConsumer(AsyncWebsocketConsumer):
         await self._forward_message(message)
 
     async def update_issue(self, message):
+        await self._forward_message(message)
+
+    async def chat_message(self, message):
         await self._forward_message(message)


### PR DESCRIPTION
## Summary

- **Chat over WebSocket**: \`RoomConsumer.receive()\` now routes \`chat_message\` frames to the room's channel group, adding a server-generated UTC timestamp before broadcast. A new \`chat_message\` channel handler forwards the message to each connected client.
- **Daphne ASGI server**: added to \`requirements.txt\` so the app can be run with \`daphne\` (needed for WebSocket support in production/Docker).
- **Configurable Redis host**: \`settings.py\` reads \`REDIS_HOST\` from the environment (defaults to \`127.0.0.1\`), enabling the channel layer to reach Redis when running inside Docker.
- **Docker support**: \`Dockerfile\` and \`.dockerignore\` added to containerise the API service. The root \`docker-compose.yml\` uses daphne as the entrypoint.

## Test plan

- [ ] \`docker compose up\` — API, Redis, and Postgres all start cleanly
- [ ] Open a room in two browser tabs, send a chat message — both tabs receive it with the correct sender name and timestamp
- [ ] Existing vote / flip / reset / update-issue flows still work after the consumer refactor
- [ ] \`REDIS_HOST\` env var routes the channel layer to the correct Redis instance in Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)