### PR TITLE
Add spectator mode

### DIFF
--- a/room/migrations/0010_participant_role.py
+++ b/room/migrations/0010_participant_role.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('room', '0009_auto_20190527_0624'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='participant',
+            name='role',
+            field=models.CharField(
+                choices=[('voter', 'Voter'), ('spectator', 'Spectator')],
+                default='voter',
+                max_length=16,
+                verbose_name='Role',
+            ),
+        ),
+    ]

--- a/room/models.py
+++ b/room/models.py
@@ -44,6 +44,10 @@ class Participant(BaseModel):
 
     """
 
+    VOTER = 'voter'
+    SPECTATOR = 'spectator'
+    ROLE_CHOICES = [(VOTER, 'Voter'), (SPECTATOR, 'Spectator')]
+
     room = models.ForeignKey(Room, verbose_name=_('Room'),
                              on_delete=models.CASCADE,
                              related_name="participants")
@@ -52,6 +56,9 @@ class Participant(BaseModel):
 
     is_creator = models.BooleanField(verbose_name=_("Is Creator"),
                                      default=False)
+
+    role = models.CharField(verbose_name=_("Role"), max_length=16,
+                            choices=ROLE_CHOICES, default=VOTER)
 
     class Meta:
         verbose_name = _("Participant")

--- a/room/serializers.py
+++ b/room/serializers.py
@@ -13,7 +13,7 @@ class ParticipantSerializerWithToken(serializers.ModelSerializer):
 
     class Meta:
         model = Participant
-        fields = ('uid', 'name', 'access_token', 'created',)
+        fields = ('uid', 'name', 'role', 'access_token', 'created',)
 
 
 class RoomSerializer(serializers.ModelSerializer):
@@ -53,6 +53,9 @@ class JoinRoomInputSerializer(serializers.Serializer):
     """Input serializer for join room."""
 
     name = serializers.CharField(required=True)
+    role = serializers.ChoiceField(
+        choices=['voter', 'spectator'], default='voter', required=False
+    )
 
 
 class SubmitRoomCurrentIssueInputSerializer(serializers.Serializer):
@@ -69,7 +72,7 @@ class ParticipantSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Participant
-        fields = ('uid', 'name', 'created',)
+        fields = ('uid', 'name', 'role', 'created',)
 
 
 class VoteSerializer(serializers.ModelSerializer):

--- a/room/views.py
+++ b/room/views.py
@@ -48,6 +48,7 @@ class JoinRoomAPIView(APIView):
         participant, created = Participant.objects.get_or_create(
             room=room,
             name=serializer.data.get("name"),
+            defaults={"role": serializer.data.get("role", "voter")},
         )
 
         serializer = ParticipantSerializerWithToken(instance=participant)
@@ -158,6 +159,12 @@ class VoteAPIView(APIView):
 
     def post(self, request, room_uid, issue_uid):
         """Submit a vote for a participant."""
+
+        if request.participant.role == 'spectator':
+            return Response(
+                data={"detail": "Spectators cannot vote."},
+                status=status.HTTP_403_FORBIDDEN
+            )
 
         issue = get_object_or_404(Issue, uid=issue_uid, room__uid=room_uid)
 


### PR DESCRIPTION
## Summary

- **Participant model**: new `role` field — `'voter'` (default) or `'spectator'`
- **Migration 0010**: adds the column; existing participants default to `'voter'`
- **Join endpoint**: accepts optional `role` in the request body and stores it on creation
- **Vote endpoint**: returns `403` if the participant is a spectator — enforced server-side so it cannot be bypassed
- **Serializers**: `role` exposed on both `ParticipantSerializer` and `ParticipantSerializerWithToken`, so the field is included in WebSocket broadcasts and REST responses

## Test plan

- [ ] `POST /rooms/<uid>/join` with `{"name": "Alice", "role": "spectator"}` — participant created with spectator role
- [ ] Spectator `POST /rooms/<uid>/issues/<uid>/votes` → `403 Forbidden`
- [ ] Voter vote submission still works
- [ ] `GET /rooms/<uid>/participants` returns `role` for each participant
- [ ] Migration applies cleanly on a fresh DB and on an existing DB with existing participants

🤖 Generated with [Claude Code](https://claude.com/claude-code)