### PR TITLE
feat: add participant_count and issue_count to room list

### DIFF
--- a/room/serializers.py
+++ b/room/serializers.py
@@ -21,10 +21,18 @@ class RoomSerializer(serializers.ModelSerializer):
 
     uid = serializers.CharField(read_only=True)
     created = serializers.CharField(read_only=True)
+    participant_count = serializers.SerializerMethodField()
+    issue_count = serializers.SerializerMethodField()
 
     class Meta:
         model = Room
-        fields = ('uid', 'title', 'description', 'updated', 'created',)
+        fields = ('uid', 'title', 'description', 'participant_count', 'issue_count', 'updated', 'created',)
+
+    def get_participant_count(self, obj):
+        return obj.participants.count()
+
+    def get_issue_count(self, obj):
+        return obj.issues.count()
 
 
 class RoomSerializerWithToken(RoomSerializer):


### PR DESCRIPTION
## Summary
- Adds `participant_count` and `issue_count` as computed fields to `RoomSerializer`
- Both are derived via `SerializerMethodField` using reverse relations — no new DB columns or migrations needed

## Test plan
- [ ] `GET /v1/rooms/` returns `participant_count` and `issue_count` on each room object

🤖 Generated with [Claude Code](https://claude.com/claude-code)