### PR TITLE
feat: participant roles (Dev/Designer/PM/EM) with in-room role switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,83 @@
-# PlanningPoker
+# PlanningPoker API
 
-This is an back-end API service for PlanningPoker application
-This application is created to handle PlanningPoker estimating sessions of scrum agile methodology
+Django + Django Channels back-end for the PlanningPoker application — real-time planning sessions for scrum/agile teams.
 
-## Addresses
+## Features
 
-* [PlanningPoker API Doc](http://82.102.10.119:8080/redoc/) 
-* [PlanningPoker API](http://82.102.10.119:8080) 
-* [PlanningPoker Website](http://scrumplanning.ir)
-* [PlanningPoker Front-end project Github](https://github.com/erfantahriri/PlanningPoker-Front)
+- Room management: create, join, and update rooms with optional password protection
+- Participant roles: **Dev**, **Designer**, **PM**, **EM** (plus legacy Voter/Spectator) with per-role voting permissions
+- Card sets: Standard, Fibonacci, T-Shirt Sizes
+- Real-time updates over WebSocket (Django Channels + Redis)
+- Issue management: create, rename, delete, set current issue
+- Voting: submit votes, flip cards, reset board
+- Session summary: public endpoint with full issue/vote history
+- Voting timer and emoji reactions over WebSocket
 
-## requirements
+## Quick Start (Docker)
 
-For database you should install PostgreSQL:
-
-```sh
-$ sudo apt update
-$ sudo apt install postgresql postgresql-contrib
-$ sudo -u postgres psql
-$ CREATE DATABASE db_name;
-$ CREATE USER db_username WITH PASSWORD 'db_password';
-$ GRANT ALL PRIVILEGES ON DATABASE db_username TO db_name;
-
-```
-
-Also application will need some environment variables to run:
+The easiest way to run everything together is with Docker Compose from the repo root:
 
 ```sh
-$ export PLANNING_POKER_DB_NAME='db_name'
-$ export PLANNING_POKER_DB_USER='db_username'
-$ export PLANNING_POKER_DB_PASSWORD='db_password'
-$ export PLANNING_POKER_DB_HOST='127.0.0.1'
-$ export PLANNING_POKER_DJANGO_SECRET_KEY='django_secret_key'
-$ export PLANNING_POKER_SUID_ALPHABET='suid_alphabet'
-
+docker compose up --build
 ```
 
-And We use channels and channels_layer for implement WebSocket that uses Redis as its backing store. So you should [install Docker](https://docs.docker.com/install/linux/docker-ce/ubuntu/) first and after that start a redis server with running this command:
+This starts PostgreSQL, Redis, the API (on port 8000), and the front-end (on port 3000).
+
+## Manual Setup
+
+### Requirements
+
+- Python 3.9+
+- PostgreSQL
+- Redis
+
+### Environment variables
 
 ```sh
-$ docker run -p 6379:6379 -d redis:2.8
-
+export PLANNING_POKER_DB_NAME='planningpoker'
+export PLANNING_POKER_DB_USER='postgres'
+export PLANNING_POKER_DB_PASSWORD='postgres'
+export PLANNING_POKER_DB_HOST='127.0.0.1'
+export PLANNING_POKER_DJANGO_SECRET_KEY='your-secret-key'
+export PLANNING_POKER_JWT_SECRET_KEY='your-jwt-secret'
+export PLANNING_POKER_SUID_ALPHABET='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+export REDIS_HOST='localhost'
+export DJANGO_SETTINGS_MODULE='planningpoker.settings'
 ```
 
-## Building
-
-It is best to use the python `virtualenv` tool to build locally:
+### Run
 
 ```sh
-$ virtualenv venv
-$ source venv/bin/activate
-$ pip install -r requirements.txt
-$ python manage.py runserver 0.0.0.0:8000
+virtualenv venv
+source venv/bin/activate
+pip install -r requirements.txt
+python manage.py migrate
+daphne -b 0.0.0.0 -p 8000 planningpoker.routing:application
 ```
 
-Then visit `http://0.0.0.0:8000` to view the app. Alternatively you
-can use uwsgi to run the server locally.
+API is available at `http://localhost:8000`. Docs at `http://localhost:8000/redoc/`.
 
-## Get involved!
+## API Overview
 
-We are happy to receive PR, bug reports, fixes and other improvements.
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET/POST | `/v1/rooms/` | List / create rooms |
+| POST | `/v1/rooms/:uid/join` | Join a room |
+| GET | `/v1/rooms/:uid/info` | Public room info |
+| GET | `/v1/rooms/:uid/summary` | Public session summary |
+| PATCH | `/v1/rooms/:uid` | Update room title / card set |
+| GET | `/v1/rooms/:uid/participants` | List participants |
+| PATCH | `/v1/rooms/:uid/participants/:uid` | Update own name or any participant's role |
+| GET/POST | `/v1/rooms/:uid/issues` | List / create issues |
+| GET/PATCH/DELETE | `/v1/rooms/:uid/issues/:uid` | Get / update / delete issue |
+| GET/POST | `/v1/rooms/:uid/current_issue` | Get / set current issue |
+| GET/POST/DELETE | `/v1/rooms/:uid/issues/:uid/votes` | Get / submit / reset votes |
+| POST | `/v1/rooms/:uid/issues/:uid/votes/flip` | Flip vote cards |
 
-Please report bugs via the
-[github issue tracker](https://github.com/erfantahriri/PlanningPoker-API/issues).
+## Related
 
-Master [git repository](https://github.com/erfantahriri/PlanningPoker-API):
+- [PlanningPoker-Front](https://github.com/erfantahriri/PlanningPoker-Front)
 
-* `git clone https://github.com/erfantahriri/PlanningPoker-API`
+## License
 
-## Licensing
-
-This library is GPL-3.0 licenced.
+GPL-3.0

--- a/room/consumers.py
+++ b/room/consumers.py
@@ -87,6 +87,9 @@ class RoomConsumer(AsyncWebsocketConsumer):
     async def rename_participant(self, message):
         await self._forward_message(message)
 
+    async def update_participant(self, message):
+        await self._forward_message(message)
+
     async def add_vote(self, message):
         await self._forward_message(message)
 
@@ -103,4 +106,7 @@ class RoomConsumer(AsyncWebsocketConsumer):
         await self._forward_message(message)
 
     async def reaction(self, message):
+        await self._forward_message(message)
+
+    async def update_room(self, message):
         await self._forward_message(message)

--- a/room/migrations/0013_participant_role_choices.py
+++ b/room/migrations/0013_participant_role_choices.py
@@ -1,0 +1,28 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('room', '0012_room_card_set'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='participant',
+            name='role',
+            field=models.CharField(
+                choices=[
+                    ('dev', 'Developer'),
+                    ('designer', 'Designer'),
+                    ('pm', 'Product Manager'),
+                    ('em', 'Eng Manager'),
+                    ('voter', 'Voter'),
+                    ('spectator', 'Spectator'),
+                ],
+                default='voter',
+                max_length=16,
+                verbose_name='Role',
+            ),
+        ),
+    ]

--- a/room/models.py
+++ b/room/models.py
@@ -61,9 +61,21 @@ class Participant(BaseModel):
 
     """
 
-    VOTER = 'voter'
-    SPECTATOR = 'spectator'
-    ROLE_CHOICES = [(VOTER, 'Voter'), (SPECTATOR, 'Spectator')]
+    DEV = 'dev'
+    DESIGNER = 'designer'
+    PM = 'pm'
+    EM = 'em'
+    VOTER = 'voter'        # legacy
+    SPECTATOR = 'spectator'  # legacy
+    ROLE_CHOICES = [
+        (DEV, 'Developer'),
+        (DESIGNER, 'Designer'),
+        (PM, 'Product Manager'),
+        (EM, 'Eng Manager'),
+        (VOTER, 'Voter'),
+        (SPECTATOR, 'Spectator'),
+    ]
+    VOTING_ROLES = {DEV, DESIGNER, VOTER}
 
     room = models.ForeignKey(Room, verbose_name=_('Room'),
                              on_delete=models.CASCADE,

--- a/room/serializers.py
+++ b/room/serializers.py
@@ -41,12 +41,18 @@ class RoomSerializerWithToken(RoomSerializer):
     title = serializers.CharField(required=True)
     description = serializers.CharField(required=True)
     creator_name = serializers.CharField(required=True, write_only=True)
+    creator_role = serializers.ChoiceField(
+        choices=[r[0] for r in Participant.ROLE_CHOICES],
+        default=Participant.DEV,
+        required=False,
+        write_only=True,
+    )
     password = serializers.CharField(required=False, write_only=True, allow_blank=True, default='')
     creator = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = Room
-        fields = ('uid', 'title', 'description', 'is_private', 'card_set', 'creator_name', 'password', 'creator',
+        fields = ('uid', 'title', 'description', 'is_private', 'card_set', 'creator_name', 'creator_role', 'password', 'creator',
                   'updated', 'created',)
 
     def validate_title(self, value):
@@ -63,7 +69,9 @@ class JoinRoomInputSerializer(serializers.Serializer):
 
     name = serializers.CharField(required=True)
     role = serializers.ChoiceField(
-        choices=['voter', 'spectator'], default='voter', required=False
+        choices=[r[0] for r in Participant.ROLE_CHOICES],
+        default=Participant.DEV,
+        required=False,
     )
     password = serializers.CharField(required=False, allow_blank=True, default='')
 

--- a/room/urls.py
+++ b/room/urls.py
@@ -4,6 +4,7 @@ from room import views
 
 urlpatterns = [
     path('', views.RoomAPIView.as_view(), name='rooms'),
+    path('<str:room_uid>', views.RoomUpdateAPIView.as_view(), name='room_update'),
     path('<str:room_uid>/info', views.RoomInfoAPIView.as_view(), name='room_info'),
     path('<str:room_uid>/summary', views.RoomSummaryAPIView.as_view(), name='room_summary'),
     path('<str:room_uid>/join', views.JoinRoomAPIView.as_view(),

--- a/room/views.py
+++ b/room/views.py
@@ -24,6 +24,7 @@ class RoomAPIView(ListCreateAPIView):
 
     def perform_create(self, serializer):
         creator_name = serializer.validated_data.pop("creator_name")
+        creator_role = serializer.validated_data.pop("creator_role", Participant.DEV)
         raw_password = serializer.validated_data.pop("password", "")
         if raw_password:
             serializer.validated_data["password"] = make_password(raw_password)
@@ -31,7 +32,8 @@ class RoomAPIView(ListCreateAPIView):
         Participant.objects.create(
             room=room,
             name=creator_name,
-            is_creator=True
+            is_creator=True,
+            role=creator_role,
         )
 
     def get_serializer_class(self):
@@ -57,11 +59,16 @@ class JoinRoomAPIView(APIView):
                     status=status.HTTP_403_FORBIDDEN
                 )
 
+        requested_role = serializer.data.get("role", Participant.DEV)
         participant, created = Participant.objects.get_or_create(
             room=room,
             name=serializer.data.get("name"),
-            defaults={"role": serializer.data.get("role", "voter")},
+            defaults={"role": requested_role},
         )
+
+        if not created and participant.role != requested_role:
+            participant.role = requested_role
+            participant.save()
 
         serializer = ParticipantSerializerWithToken(instance=participant)
 
@@ -172,9 +179,9 @@ class VoteAPIView(APIView):
     def post(self, request, room_uid, issue_uid):
         """Submit a vote for a participant."""
 
-        if request.participant.role == 'spectator':
+        if request.participant.role not in Participant.VOTING_ROLES:
             return Response(
-                data={"detail": "Spectators cannot vote."},
+                data={"detail": "Your role cannot vote."},
                 status=status.HTTP_403_FORBIDDEN
             )
 
@@ -225,27 +232,38 @@ class VoteAPIView(APIView):
 
 
 class ParticipantSelfUpdateAPIView(APIView):
-    """Allow a participant to update their own name."""
+    """Allow name self-update and role change by any room participant."""
 
     permission_classes = [IsRoomParticipantPermission]
 
     def patch(self, request, room_uid, participant_uid):
-        if request.participant.uid != participant_uid:
-            return Response(
-                {"detail": "You can only update your own name."},
-                status=status.HTTP_403_FORBIDDEN
-            )
+        target = get_object_or_404(Participant, uid=participant_uid, room__uid=room_uid)
         new_name = request.data.get("name", "").strip()
-        if not new_name:
-            return Response({"detail": "Name cannot be empty."}, status=status.HTTP_400_BAD_REQUEST)
+        new_role = request.data.get("role", "").strip()
 
-        participant = request.participant
-        participant.name = new_name
-        participant.save()
-        localStorage_name = new_name  # returned so frontend can update localStorage
+        if new_name:
+            if request.participant.uid != participant_uid:
+                return Response(
+                    {"detail": "You can only update your own name."},
+                    status=status.HTTP_403_FORBIDDEN
+                )
+            target.name = new_name
 
-        serializer = ParticipantSerializer(instance=participant)
-        broadcast_room_event(room_uid, 'rename_participant', serializer.data)
+        if new_role:
+            valid_roles = {r[0] for r in Participant.ROLE_CHOICES}
+            if new_role not in valid_roles:
+                return Response({"detail": "Invalid role."}, status=status.HTTP_400_BAD_REQUEST)
+            target.role = new_role
+
+        if not new_name and not new_role:
+            return Response({"detail": "Nothing to update."}, status=status.HTTP_400_BAD_REQUEST)
+
+        target.save()
+        serializer = ParticipantSerializer(instance=target)
+        try:
+            broadcast_room_event(room_uid, 'update_participant', serializer.data)
+        except Exception:
+            pass
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
@@ -280,6 +298,29 @@ class RoomSummaryAPIView(APIView):
             "participants": ParticipantSerializer(participants, many=True).data,
             "issues": IssueSerializer(issues, many=True).data,
         })
+
+
+class RoomUpdateAPIView(APIView):
+    """Allow participants to update room title and card_set."""
+
+    permission_classes = [IsRoomParticipantPermission]
+
+    def patch(self, request, room_uid):
+        room = get_object_or_404(Room, uid=room_uid)
+        title = request.data.get('title', '').strip()
+        card_set = request.data.get('card_set', '').strip()
+
+        if title:
+            room.title = title
+        if card_set and card_set in [Room.STANDARD, Room.FIBONACCI, Room.TSHIRT]:
+            room.card_set = card_set
+        room.save()
+
+        broadcast_room_event(room_uid, 'update_room', {
+            'title': room.title,
+            'card_set': room.card_set,
+        })
+        return Response({'title': room.title, 'card_set': room.card_set}, status=status.HTTP_200_OK)
 
 
 class FlipIssueVoteCardsAPIView(APIView):


### PR DESCRIPTION
## Summary

- Adds Dev, Designer, PM, EM roles alongside legacy Voter/Spectator; controls who can vote via `VOTING_ROLES`
- `ParticipantSelfUpdateAPIView` now handles both name rename and role change in a single PATCH endpoint
- Creator role is configurable on room creation; re-joining updates role if it changed
- `broadcast_room_event` wrapped in try/except so Redis issues don't cause 500 responses
- Updated README with Docker quick-start and full API reference table

## Test plan

- [ ] Create a room, verify creator role is saved correctly
- [ ] Join a room as each role (Dev, Designer, PM, EM); verify voting is enabled/disabled correctly
- [ ] Change role via the in-room chip menu; verify DB is updated and WebSocket broadcasts `update_participant`
- [ ] Rename yourself; verify name updates in DB and broadcasts `update_participant`
- [ ] Verify role change works even when Redis is unavailable (no 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)