### PR TITLE
feat: add Swagger UI endpoint

### DIFF
--- a/planningpoker/urls.py
+++ b/planningpoker/urls.py
@@ -20,5 +20,6 @@ schema_view = get_schema_view(
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('v1/rooms/', include('room.urls')),
+    re_path(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     re_path(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
 ]


### PR DESCRIPTION
## Summary
- Adds the Swagger UI route (`/swagger/`) to `urlpatterns` alongside the existing ReDoc route

## Test plan
- [ ] Visit `http://localhost:8000/swagger/` and confirm Swagger UI loads
- [ ] Visit `http://localhost:8000/redoc/` and confirm ReDoc still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)